### PR TITLE
Fix release workflow by creating tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
           git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }}"
           git push
 
+      - name: 🏷️ Create tag
+        run: |
+          git tag ${{ steps.bump.outputs.tag }}
+          git push origin ${{ steps.bump.outputs.tag }}
+
       - name: ☕ Set up Java
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
## Summary
- create and push git tag before publishing a release

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6859bf83bec083259af786d23226f457