### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -33,3 +33,14 @@ jobs:
         with:
           name: sunsync-dev-debug
           path: app/build/outputs/apk/debug/app-debug.apk
+
+      - name: Publish Dev APK to Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: dev
+          name: Development Build
+          allowUpdates: true
+          prerelease: true
+          replacesArtifacts: true
+          artifacts: app/build/outputs/apk/debug/app-debug.apk
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,15 @@ jobs:
 
       - name: 📁 Rename APK to include version
         run: |
+          set -eo pipefail
           mkdir -p release
-          cp app/build/outputs/apk/release/app-release.apk release/sunsync-${{ steps.bump.outputs.new_version }}.apk
+          apk_path=$(find app/build/outputs/apk -name "*release*.apk" -print -quit)
+          if [ -z "$apk_path" ]; then
+            echo "Unable to locate release APK" >&2
+            ls -R app/build/outputs || true
+            exit 1
+          fi
+          cp "$apk_path" "release/sunsync-${{ steps.bump.outputs.new_version }}.apk"
 
       - name: 🚀 Upload to GitHub Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
## Summary
- adjust release workflow to locate the built APK more reliably
- publish dev builds directly to a `dev` GitHub release

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails to find Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_685aaf2fb6e8832598d7ffc9b920cf60